### PR TITLE
Fix missing exposed folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,6 @@
     "suggest": {
         "nswdpc/silverstripe-recaptcha-v3-userforms": "Adding reCAPTCHA v3 field via silverstripe/userforms"
     },
-    "extra": {
-        "expose": [
-            "client/dist"
-        ]
-    },
     "authors": [
         {
             "name": "James Ellis",


### PR DESCRIPTION
- Remove the exposed folder as it does not seem to have any use.
- Exposed folder is missing and is throwing an error when deploying code to Silverstripe Cloud

Reported issue: https://github.com/nswdpc/silverstripe-recaptcha-v3/issues/2