### PR TITLE
Badge placement

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,10 +1,13 @@
 /tests  export-ignore
 /docs export-ignore
 /client/src export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.php_cs.dist
-/.phpcs.xml.dist
-/.phpunit.xml.dist
+/.php_cs.dist export-ignore
+/phpcs.xml.dist export-ignore
+/phpunit.xml.dist export-ignore
 /.waratah export-ignore
+/code_of_conduct.md export-ignore
+/CONTRIBUTING.md export-ignore
 /README.md export-ignore

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ NSWDPC\SpamProtection\RecaptchaV3Field:
   site_key: 'zyx321.....'
   # Global action prefix for the field
   execute_action: 'submit'
+  # Place the reCAPTCHA badge in the form
+  badge_display: 'form'
 ```
 
 ## Token retrieval

--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@ You can also use the module to verify tokens/actions from non-form interactions 
 
 > The default score for verification is 0.7, you can change this in project configuration
 
+## Installation
+
+Install via composer
+
+```shell
+composer require nswdpc/silverstripe-recaptcha-v3
+```
+
 ## Requirements
 
-See [composer.json](./composer.json) but in summary:
+See [composer.json](./composer.json), but in summary:
 
 + silverstripe/framework ^4
 + silverstripe/spamprotection ^3
@@ -43,14 +51,16 @@ SilverStripe\SpamProtection\Extension\FormSpamProtectionExtension:
   default_spam_protector: NSWDPC\SpamProtection\RecaptchaV3SpamProtector
 ```
 
-Then calling `$form->enableSpamProtection()` will add the field to the form automatically.
+Then calling `$form->enableSpamProtection()` will add the field to the form automatically. Read the [silverstripe/spamprotection documentation](https://github.com/silverstripe/silverstripe-spamprotection#configuring) for more information on how this works.
 
 ### Field for silverstripe/userforms modules
 
 The module `nswdpc/silverstripe-recaptcha-v3-userforms` provides a userforms field
 
-## Documentation
- * [Further documentation](docs/en/index.md) for tips on usage
+## Further documentation
+
++ [Further documentation](docs/en/001_index.md) for tips on usage
++ [Badge placement](docs/en/001_badge_display.md)
 
 ## Configuration
 
@@ -84,8 +94,9 @@ NSWDPC\SpamProtection\RecaptchaV3Field:
   site_key: 'zyx321.....'
   # Global action prefix for the field
   execute_action: 'submit'
-  # Place the reCAPTCHA badge in the form
-  badge_display: 'form'
+NSWDPC\SpamProtection\RecaptchaV3SpamProtector:
+  # Place the reCAPTCHA privacy text adjacent to the hidden input form field
+  badge_display: 'field'
 ```
 
 ## Token retrieval
@@ -95,14 +106,6 @@ The behaviour triggering a token retrieval from the reCAPTCHAv3 API is a focus()
 When the first field in a form is focused, a token will be retrieved. If another field is focused in the form after 30 seconds, the token will be refreshed.
 
 The latest token will be submitted with the form and validated, if it has expired, the visitor will be prompted to check and resubmit the form.
-
-## Installation
-
-Install via composer
-
-```
-composer require nswdpc/silverstripe-recaptcha-v3
-```
 
 ## License
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,3 +12,5 @@ NSWDPC\SpamProtection\RecaptchaV3Field:
   site_key: ''
   # Global action prefix for the field
   execute_action: 'submit'
+  # How the badge is displayed
+  badge_display: ''

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -12,5 +12,7 @@ NSWDPC\SpamProtection\RecaptchaV3Field:
   site_key: ''
   # Global action prefix for the field
   execute_action: 'submit'
+NSWDPC\SpamProtection\RecaptchaV3SpamProtector:
   # How the badge is displayed
+  # Options: '','field','form','page'
   badge_display: ''

--- a/docs/en/001_index.md
+++ b/docs/en/001_index.md
@@ -41,11 +41,7 @@ $field->setExecuteAction('myaction');
 
 ## reCAPTCHA badge placement
 
-You can place the badge in one of three locations using the `NSWDPC\SpamProtection\RecaptchaV3Field.badge_display` configuration value.
-
-1. Empty string (default): The badge will automatically appear in the lower right corner of the viewport
-1. `form`: the [replacement text](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) is displayed adjacent to the hidden recaptcha input. The default badge is hidden with CSS.
-1. `page`: no badge or text is displayed. It's up to you to "include the reCAPTCHA branding visibly in the user flow". The default badge is hidden with CSS.
+See [badge display](./002_badge_display.md)
 
 ## Controller verification
 

--- a/docs/en/002_badge_display.md
+++ b/docs/en/002_badge_display.md
@@ -1,0 +1,66 @@
+# Badge display
+ 
+You can place the badge in one of four locations using the `NSWDPC\SpamProtection\RecaptchaV3SpamProtector.badge_display` configuration value:
+
+```yaml
+---
+Name: 'my-spam-protector-config'
+After:
+ - '#nswdpc_recaptchav3_spamprotection'
+---
+NSWDPC\SpamProtection\RecaptchaV3SpamProtector:
+  # options are '','field','form','page'
+  badge_display: 'field'
+```
+
+## Default
+
+Value: empty string
+
+The badge will automatically appear in the lower right corner of the viewport.
+
+## Field
+
+Value: 'field'
+
+The [replacement text](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) is automatically displayed adjacent to the hidden recaptcha input.
+
+Unless you have a custom form template, the privacy information will display before the form actions.
+
+The default badge is hidden using CSS. Calling `$ReCAPTCHAv3PrivacyInformation` in the template hides the default badge.
+
+## Form
+
+Value: 'form'
+ 
+Provided you have a custom form template, the [replacement text](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) can be displayed in the form template, in a location of your choice:
+
+```html
+<%-- themes/my-project-theme/templates/SilverStripe/Forms/Includes/Form.ss --%>
+<% if $ReCAPTCHAv3BadgeDisplay == 'form' %>
+    {$ReCAPTCHAv3PrivacyInformation}
+<% end_if %>
+```
+
+If you provide specific form templates, this will need to be added to each template, as required.
+
+The default badge is hidden using CSS. Calling `$ReCAPTCHAv3PrivacyInformation` in the template hides the default badge.
+
+## Page
+
+Value: 'page'
+
+No badge or text is displayed. It's up to you to "include the reCAPTCHA branding visibly in the user flow" in your theme's page template.
+
+Example:
+```html
+<footer>
+<% if $ReCAPTCHAv3BadgeDisplay == 'page' %>
+    {$ReCAPTCHAv3PrivacyInformation}
+<% end_if %>
+</footer>
+```
+
+The default badge is hidden using CSS. Calling `$ReCAPTCHAv3PrivacyInformation` in the template hides the default badge.
+
+[Back to the index](./001_index.md)

--- a/docs/en/002_badge_display.md
+++ b/docs/en/002_badge_display.md
@@ -46,6 +46,10 @@ If you provide specific form templates, this will need to be added to each templ
 
 The default badge is hidden using CSS. Calling `$ReCAPTCHAv3PrivacyInformation` in the template hides the default badge.
 
+### Direct include
+
+You can also `<% include NSWDPC/SpamProtection/FormBadge %>` in a form template.
+
 ## Page
 
 Value: 'page'
@@ -62,5 +66,10 @@ Example:
 ```
 
 The default badge is hidden using CSS. Calling `$ReCAPTCHAv3PrivacyInformation` in the template hides the default badge.
+
+### Direct include
+
+You can also `<% include NSWDPC/SpamProtection/PageBadge %>` in a page template.
+
 
 [Back to the index](./001_index.md)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -39,6 +39,14 @@ $field->setExecuteAction('myaction');
 ```
 [Valid characters in an action are `a-z A-Z 0-9 /`](https://developers.google.com/recaptcha/docs/v3#actions)
 
+## reCAPTCHA badge placement
+
+You can place the badge in one of three locations using the `NSWDPC\SpamProtection\RecaptchaV3Field.badge_display` configuration value.
+
+1. Empty string (default): The badge will automatically appear in the lower right corner of the viewport
+1. `form`: the [replacement text](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed) is displayed adjacent to the hidden recaptcha input. The default badge is hidden with CSS.
+1. `page`: no badge or text is displayed. It's up to you to "include the reCAPTCHA branding visibly in the user flow". The default badge is hidden with CSS.
+
 ## Controller verification
 
 The module provides a controller to verify tokens and actions beyond a standard form submission.

--- a/src/Forms/RecaptchaV3Field.php
+++ b/src/Forms/RecaptchaV3Field.php
@@ -219,7 +219,7 @@ class RecaptchaV3Field extends HiddenField {
          */
         $refresh_on_error = "";
 
-        if(($errors = $this->getForm()->getSessionValidationResult()) && !$errors->isValid()) {
+        if(($form = $this->getForm()) && ($errors = $form->getSessionValidationResult()) && !$errors->isValid()) {
             $refresh_on_error = "recaptcha_execute_handler(form);";
         }
 

--- a/src/Forms/RecaptchaV3Field.php
+++ b/src/Forms/RecaptchaV3Field.php
@@ -63,19 +63,6 @@ class RecaptchaV3Field extends HiddenField {
      */
     private $has_prefixed_action = false;
 
-    /**
-     * Badge display options: empty string, 'form' or 'page'
-     * If page it is up to you to to include NSWDPC/SpamProtection/PageBadge in your template in the appropriate location
-     * See: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
-     * @param string
-     */
-    private static $badge_display = "";
-
-
-    const BADGE_DISPLAY_DEFAULT = '';// use the reCAPTCHAv3 library default (fixed bottom right)
-    const BADGE_DISPLAY_FORM = 'form';// display the badge text in the form, above the actions
-    const BADGE_DISPLAY_PAGE = 'page';// display the badge text in the page somewhere
-
 
     public function __construct($name, $title = null, $value = null)
     {
@@ -374,26 +361,6 @@ JS;
         $this->setSubmittedValue("");
         // fail validation
         return false;
-    }
-
-    /**
-     * Return some information for templates to display the RecaptchaV3Badge
-     * Returns an empty string, 'form' or 'page'
-     */
-    public function ShowRecaptchaV3Badge() : string {
-        $displayOption = $this->config()->get('badge_display');
-        switch($displayOption) {
-            case self::BADGE_DISPLAY_FORM:
-            case self::BADGE_DISPLAY_PAGE:
-                $css = ".grecaptcha-badge { visibility: hidden; }";
-                Requirements::customCSS($css, 'recaptcha_badge_hide');
-                break;
-            case self::BADGE_DISPLAY_DEFAULT:
-            default:
-                $displayOption = '';
-                break;
-        }
-        return $displayOption;
     }
 
 }

--- a/src/Forms/RecaptchaV3Field.php
+++ b/src/Forms/RecaptchaV3Field.php
@@ -63,6 +63,19 @@ class RecaptchaV3Field extends HiddenField {
      */
     private $has_prefixed_action = false;
 
+    /**
+     * Badge display options: empty string, 'form' or 'page'
+     * If page it is up to you to to include NSWDPC/SpamProtection/PageBadge in your template in the appropriate location
+     * See: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed
+     * @param string
+     */
+    private static $badge_display = "";
+
+
+    const BADGE_DISPLAY_DEFAULT = '';// use the reCAPTCHAv3 library default (fixed bottom right)
+    const BADGE_DISPLAY_FORM = 'form';// display the badge text in the form, above the actions
+    const BADGE_DISPLAY_PAGE = 'page';// display the badge text in the page somewhere
+
 
     public function __construct($name, $title = null, $value = null)
     {
@@ -361,6 +374,26 @@ JS;
         $this->setSubmittedValue("");
         // fail validation
         return false;
+    }
+
+    /**
+     * Return some information for templates to display the RecaptchaV3Badge
+     * Returns an empty string, 'form' or 'page'
+     */
+    public function ShowRecaptchaV3Badge() : string {
+        $displayOption = $this->config()->get('badge_display');
+        switch($displayOption) {
+            case self::BADGE_DISPLAY_FORM:
+            case self::BADGE_DISPLAY_PAGE:
+                $css = ".grecaptcha-badge { visibility: hidden; }";
+                Requirements::customCSS($css, 'recaptcha_badge_hide');
+                break;
+            case self::BADGE_DISPLAY_DEFAULT:
+            default:
+                $displayOption = '';
+                break;
+        }
+        return $displayOption;
     }
 
 }

--- a/src/Models/RecaptchaV3SpamProtector.php
+++ b/src/Models/RecaptchaV3SpamProtector.php
@@ -198,7 +198,6 @@ class RecaptchaV3SpamProtector implements SpamProtector, TemplateGlobalProvider
      */
     public static function get_privacy_information() {
         $displayOption = self::config()->get('badge_display');
-        var_dump($displayOption);
         $value = '';
         switch($displayOption) {
             case self::BADGE_DISPLAY_FORM:

--- a/templates/NSWDPC/SpamProtection/Includes/FormBadge.ss
+++ b/templates/NSWDPC/SpamProtection/Includes/FormBadge.ss
@@ -1,0 +1,3 @@
+<p class="recaptchav3 form-badge">
+<%t NSWDPC\SpamProtection.THIS_FORM_IS_PROTECTED_BY_RECAPTCHA 'This form is protected by reCAPTCHA and the Google' %> <a href="https://policies.google.com/privacy" target="_blank"><%t NSWDPC\SpamProtection.RECAPTCHA_PRIVACY_POLICY 'Privacy Policy' %></a> and <a href="https://policies.google.com/terms" target="_blank"><%t NSWDPC\SpamProtection.RECAPTCHA_TERMS_OF_SERVICE 'Terms of Service' %></a> apply.
+</p>

--- a/templates/NSWDPC/SpamProtection/Includes/PageBadge.ss
+++ b/templates/NSWDPC/SpamProtection/Includes/PageBadge.ss
@@ -1,0 +1,3 @@
+<p class="recaptchav3 page-badge">
+<%t NSWDPC\SpamProtection.THIS_SITE_IS_PROTECTED_BY_RECAPTCHA 'This site is protected by reCAPTCHA and the Google' %> <a href="https://policies.google.com/privacy" target="_blank"><%t NSWDPC\SpamProtection.RECAPTCHA_PRIVACY_POLICY 'Privacy Policy' %></a> and <a href="https://policies.google.com/terms" target="_blank"><%t NSWDPC\SpamProtection.RECAPTCHA_TERMS_OF_SERVICE 'Terms of Service' %></a> apply.
+</p>

--- a/templates/NSWDPC/SpamProtection/PrivacyInformation.ss
+++ b/templates/NSWDPC/SpamProtection/PrivacyInformation.ss
@@ -1,0 +1,5 @@
+<% if $DisplayOption == 'form' || $DisplayOption == 'field' %>
+    <% include NSWDPC/SpamProtection/FormBadge %>
+<% else_if $DisplayOption == 'page' %>
+    <% include NSWDPC/SpamProtection/PageBadge %>
+<% end_if %>

--- a/templates/NSWDPC/SpamProtection/RecaptchaV3Field_holder.ss
+++ b/templates/NSWDPC/SpamProtection/RecaptchaV3Field_holder.ss
@@ -1,2 +1,6 @@
 $Field
 <% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
+
+<% if $ShowRecaptchaV3Badge == 'form' %>
+<% include NSWDPC/SpamProtection/FormBadge %>
+<% end_if %>

--- a/templates/NSWDPC/SpamProtection/RecaptchaV3Field_holder.ss
+++ b/templates/NSWDPC/SpamProtection/RecaptchaV3Field_holder.ss
@@ -1,6 +1,7 @@
+
 $Field
 <% if $Message %><span class="message $MessageType">$Message</span><% end_if %>
 
-<% if $ShowRecaptchaV3Badge == 'form' %>
-<% include NSWDPC/SpamProtection/FormBadge %>
+<% if $ReCAPTCHAv3BadgeDisplay == 'field' %>
+    {$ReCAPTCHAv3PrivacyInformation}
 <% end_if %>

--- a/tests/RecaptchaV3FieldBadgePlacementTest.php
+++ b/tests/RecaptchaV3FieldBadgePlacementTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace NSWDPC\SpamProtection\Tests;
+
+use NSWDPC\SpamProtection\RecaptchaV3Field;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * Test badge placement
+ * @author James
+ */
+class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
+{
+
+    protected $usesDatabase = false;
+
+    public function testDefaultBadgePlacement() {
+        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_DEFAULT);
+        $field = RecaptchaV3Field::create(
+            'test_default_badge'
+        );
+        $displayOption = $field->ShowRecaptchaV3Badge();
+        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_DEFAULT, $displayOption, "ShowRecaptchaV3Badge returned empty");
+
+        $template = $field->FieldHolder()->forTemplate();
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+    }
+
+    public function testFormBadgePlacement() {
+        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_FORM);
+        $field = RecaptchaV3Field::create(
+            'test_default_badge'
+        );
+        $displayOption = $field->ShowRecaptchaV3Badge();
+        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_FORM, $displayOption, "ShowRecaptchaV3Badge returned form setting");
+
+        $template = $field->FieldHolder()->forTemplate();
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") !== false, "Recatpcha policy link in template");
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") !== false, "Recatpcha T&C link in template");
+    }
+
+    public function testPageBadgePlacement() {
+        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_PAGE);
+        $field = RecaptchaV3Field::create(
+            'test_default_badge'
+        );
+        $displayOption = $field->ShowRecaptchaV3Badge();
+        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_PAGE, $displayOption, "ShowRecaptchaV3Badge returned page setting");
+
+        $template = $field->FieldHolder()->forTemplate();
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+
+    }
+}

--- a/tests/RecaptchaV3FieldBadgePlacementTest.php
+++ b/tests/RecaptchaV3FieldBadgePlacementTest.php
@@ -3,6 +3,7 @@
 namespace NSWDPC\SpamProtection\Tests;
 
 use NSWDPC\SpamProtection\RecaptchaV3Field;
+use NSWDPC\SpamProtection\RecaptchaV3SpamProtector;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 
@@ -16,12 +17,12 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
     protected $usesDatabase = false;
 
     public function testDefaultBadgePlacement() {
-        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_DEFAULT);
+        Config::modify()->set(RecaptchaV3SpamProtector::class, 'badge_display', RecaptchaV3SpamProtector::BADGE_DISPLAY_DEFAULT);
         $field = RecaptchaV3Field::create(
             'test_default_badge'
         );
-        $displayOption = $field->ShowRecaptchaV3Badge();
-        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_DEFAULT, $displayOption, "ShowRecaptchaV3Badge returned empty");
+        $displayOption = RecaptchaV3SpamProtector::get_badge_display();
+        $this->assertEquals(RecaptchaV3SpamProtector::BADGE_DISPLAY_DEFAULT, $displayOption, "ShowRecaptchaV3Badge returned empty");
 
         $template = $field->FieldHolder()->forTemplate();
 
@@ -30,13 +31,13 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
         $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
     }
 
-    public function testFormBadgePlacement() {
-        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_FORM);
+    public function testFieldBadgePlacement() {
+        Config::modify()->set(RecaptchaV3SpamProtector::class, 'badge_display', RecaptchaV3SpamProtector::BADGE_DISPLAY_FIELD);
         $field = RecaptchaV3Field::create(
-            'test_default_badge'
+            'test_field_badge'
         );
-        $displayOption = $field->ShowRecaptchaV3Badge();
-        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_FORM, $displayOption, "ShowRecaptchaV3Badge returned form setting");
+        $displayOption = RecaptchaV3SpamProtector::get_badge_display();
+        $this->assertEquals(RecaptchaV3SpamProtector::BADGE_DISPLAY_FIELD, $displayOption, "ShowRecaptchaV3Badge returned field setting");
 
         $template = $field->FieldHolder()->forTemplate();
 
@@ -45,13 +46,29 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
         $this->assertTrue( strpos($template, "https://policies.google.com/terms") !== false, "Recatpcha T&C link in template");
     }
 
-    public function testPageBadgePlacement() {
-        Config::modify()->set(RecaptchaV3Field::class, 'badge_display', RecaptchaV3Field::BADGE_DISPLAY_PAGE);
+    public function testFormBadgePlacement() {
+        Config::modify()->set(RecaptchaV3SpamProtector::class, 'badge_display', RecaptchaV3SpamProtector::BADGE_DISPLAY_FORM);
         $field = RecaptchaV3Field::create(
-            'test_default_badge'
+            'test_form_badge'
         );
-        $displayOption = $field->ShowRecaptchaV3Badge();
-        $this->assertEquals(RecaptchaV3Field::BADGE_DISPLAY_PAGE, $displayOption, "ShowRecaptchaV3Badge returned page setting");
+        $displayOption = RecaptchaV3SpamProtector::get_badge_display();
+        $this->assertEquals(RecaptchaV3SpamProtector::BADGE_DISPLAY_FORM, $displayOption, "ShowRecaptchaV3Badge returned page setting");
+
+        $template = $field->FieldHolder()->forTemplate();
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+
+    }
+
+    public function testPageBadgePlacement() {
+        Config::modify()->set(RecaptchaV3SpamProtector::class, 'badge_display', RecaptchaV3SpamProtector::BADGE_DISPLAY_PAGE);
+        $field = RecaptchaV3Field::create(
+            'test_page_badge'
+        );
+        $displayOption = RecaptchaV3SpamProtector::get_badge_display();
+        $this->assertEquals(RecaptchaV3SpamProtector::BADGE_DISPLAY_PAGE, $displayOption, "ShowRecaptchaV3Badge returned page setting");
 
         $template = $field->FieldHolder()->forTemplate();
 

--- a/tests/RecaptchaV3FieldBadgePlacementTest.php
+++ b/tests/RecaptchaV3FieldBadgePlacementTest.php
@@ -26,9 +26,9 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
 
         $template = $field->FieldHolder()->forTemplate();
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recaptcha policy link not in template");
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recaptcha T&C link not in template");
     }
 
     public function testFieldBadgePlacement() {
@@ -41,9 +41,9 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
 
         $template = $field->FieldHolder()->forTemplate();
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") !== false, "Recatpcha policy link in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") !== false, "Recaptcha policy link in template");
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/terms") !== false, "Recatpcha T&C link in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") !== false, "Recaptcha T&C link in template");
     }
 
     public function testFormBadgePlacement() {
@@ -56,9 +56,9 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
 
         $template = $field->FieldHolder()->forTemplate();
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recaptcha policy link not in template");
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recaptcha T&C link not in template");
 
     }
 
@@ -72,9 +72,9 @@ class RecaptchaV3FieldBadgePlacementTest extends SapphireTest
 
         $template = $field->FieldHolder()->forTemplate();
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recatpcha policy link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/privacy") === false, "Recaptcha policy link not in template");
 
-        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recatpcha T&C link not in template");
+        $this->assertTrue( strpos($template, "https://policies.google.com/terms") === false, "Recaptcha T&C link not in template");
 
     }
 }


### PR DESCRIPTION
Refer Issue #1  - Badge position and display 

Changes
+ Add badge display options - default (floating), in field, in form, in page
+ Add tests
+ Add documentation
+ Clean up dev requirements

See: https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-badge.-what-is-allowed